### PR TITLE
feat: Bump typegpu to 0.5.7

### DIFF
--- a/common.ts
+++ b/common.ts
@@ -1,3 +1,3 @@
-export * as d from "https://esm.sh/typegpu@0.5.3/data"
+export * as d from "https://esm.sh/typegpu@0.5.7/data?bundle=false"
 export * from "./src/types.ts"
 export * from "./src/Lil.ts"

--- a/src/DenoGpuWrapper.ts
+++ b/src/DenoGpuWrapper.ts
@@ -5,7 +5,7 @@ import {
 
 import { Layout } from "./types.ts"
 
-import tgpu, { TgpuRoot } from "https://esm.sh/typegpu@0.5.3"
+import tgpu, { TgpuRoot } from "https://esm.sh/typegpu@0.5.7?bundle=false"
 
 import { createCapture } from "jsr:@std/webgpu@0.224.7"
 import { copyToBuffer, createPng } from "./denoUtil.ts"

--- a/src/Lil.ts
+++ b/src/Lil.ts
@@ -1,5 +1,6 @@
 import {
     AnyWgslData,
+    Infer,
     TgpuLayoutEntry,
     TgpuLayoutStorage,
 } from "./deps.ts"
@@ -42,7 +43,7 @@ const layoutDecorator =
 accessorDecorator(
     (lil: This) =>
     (...args: Args) => ({
-        getV: (v: T["~repr"]) => v,
+        getV: (v: Infer<T>) => v,
         setV: (v, { name }) => {
             lil.update(
                 name as This["__t_keys"],

--- a/src/deps.ts
+++ b/src/deps.ts
@@ -4,6 +4,6 @@ export {
     type TgpuLayoutEntry,
     type TgpuLayoutStorage,
     type UniformFlag,
-} from "https://esm.sh/typegpu@0.5.3"
+} from "https://esm.sh/typegpu@0.5.7?bundle=false"
 
-export * from "https://esm.sh/typegpu@0.5.3/data"
+export * from "https://esm.sh/typegpu@0.5.7/data?bundle=false"


### PR DESCRIPTION
Hi! 👋
I noticed in your release notes that the latest version of typegpu you could upgrade to was 0.5.3 due to a runtime error in 0.5.4-0.5.7. We noticed this too in our benchmark app, which uses `esm.sh` for downloading multiple versions of the library for comparison.

Because as of 0.5.4, we're using symbols to determine whether or not something comes from `typegpu`, it became very delicate to duplication. We're essentially disallowing multiple instances of the library to interact with each other. Because the import to `typegpu` and `typegpu/data` were being bundled separately by `esm.sh`, some definitions were duplicated. The `?bundle=false` flag fixes this issue, and since we bundle up the library before publishing anyway, there should not be a dramatic increase in additional network requests 🙏

Thanks for using TypeGPU, let me know if we can do anything to make it more pleasant to work with!